### PR TITLE
Adding language option. 

### DIFF
--- a/lib/pastery.coffee
+++ b/lib/pastery.coffee
@@ -22,9 +22,11 @@ module.exports = Pastery =
     apiKey = atom.config.get('pastery.a_apiKey')
     views = atom.config.get('pastery.c_views')
     expiration = atom.config.get('pastery.b_expiration')
+    syntaxLanguage = atom.config.get('pastery.g_languageSyntax')
 
     qs = {}
     qs.title = fileName
+    qs.language = syntaxLanguage
     if views > 0
       qs.max_views = views
     if expiration > 0

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -30,3 +30,8 @@ module.exports =
       type: 'integer'
       default: 3
       description: 'If notification option is enabled, dismiss it after given seconds'
+    g_languageSyntax:
+      title: 'Syntax Highlighting'
+      type: 'string'
+      default: 'autodetect'
+      description: 'Sets the language for syntax highlighting'      


### PR DESCRIPTION
Code fragments which are too small have trouble with the autodetect. Adding language option to get around this limitation.